### PR TITLE
resolve migration issue when integer fields contain empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Resolve migration issue when integer fields contain empty strings ([#5](https://github.com/scm-manager/scm-notify-plugin/pull/5))
+
 ## 2.0.0 - 2020-06-04
 ### Changed
 - Changeover to MIT license ([#2](https://github.com/scm-manager/scm-notify-plugin/pull/2))

--- a/src/main/java/sonia/scm/notify/update/NotifyV2RepositoryConfigMigrationUpdateStep.java
+++ b/src/main/java/sonia/scm/notify/update/NotifyV2RepositoryConfigMigrationUpdateStep.java
@@ -38,6 +38,7 @@ import sonia.scm.version.Version;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 import static sonia.scm.update.V1PropertyReader.REPOSITORY_PROPERTY_READER;
 import static sonia.scm.version.Version.parse;
@@ -86,7 +87,7 @@ public class NotifyV2RepositoryConfigMigrationUpdateStep implements UpdateStep {
     NotifyRepositoryConfiguration v2NotifyRepositoryConfiguration = new NotifyRepositoryConfiguration();
     v2NotifyRepositoryConfiguration.setContactList(contactList);
     v2NotifyRepositoryConfiguration.setEmailPerPush(Boolean.parseBoolean(properties.get(NOTIFY_EMAIL_PER_PUSH)));
-    v2NotifyRepositoryConfiguration.setMaxDiffLines(Integer.parseInt(properties.get(NOTIFY_MAX_DIFF_LINES)));
+    v2NotifyRepositoryConfiguration.setMaxDiffLines(safeParseInt(properties.get(NOTIFY_MAX_DIFF_LINES)));
     v2NotifyRepositoryConfiguration.setSendToRepositoryContact(Boolean.parseBoolean(properties.get(NOTIFY_REPOSITORY_CONTACT)));
     v2NotifyRepositoryConfiguration.setUseAuthorAsFromAddress(Boolean.parseBoolean(properties.get(NOTIFY_USE_AUTHOR)));
 
@@ -95,6 +96,18 @@ public class NotifyV2RepositoryConfigMigrationUpdateStep implements UpdateStep {
 
   private ConfigurationStore<NotifyRepositoryConfiguration> createConfigStore(String repositoryId) {
     return storeFactory.withType(NotifyRepositoryConfiguration.class).withName(STORE_NAME).forRepository(repositoryId).build();
+  }
+
+  private <T> T safeParse(String str, T fallback, Function<String, T> parser) {
+    if (str == null || str.trim().equals("")) {
+      return fallback;
+    } else {
+      return parser.apply(str);
+    }
+  }
+
+  private int safeParseInt(String str) {
+    return safeParse(str, 0, Integer::parseInt);
   }
 
   @Override

--- a/src/test/java/sonia/scm/notify/update/NotifyV2RepositoryConfigMigrationUpdateStepTest.java
+++ b/src/test/java/sonia/scm/notify/update/NotifyV2RepositoryConfigMigrationUpdateStepTest.java
@@ -75,6 +75,30 @@ public class NotifyV2RepositoryConfigMigrationUpdateStepTest {
   }
 
   @Test
+  public void shouldMigratingForRepositoryIfMaxDiffLinesAreAnEmptyString() {
+    ImmutableMap<String, String> mockedValues =
+      ImmutableMap.of(
+        "notify.contact.repository","true",
+        "notify.max.diff.lines", "",
+        "notify.contact.list", "dritte@email.de;echo@off.de;abc@def.de;",
+        "notify.email.per.push", "true",
+        "notify.use.author.as.from.address", "false"
+      );
+
+    testUtil.mockRepositoryProperties(new V1PropertyDaoTestUtil.PropertiesForRepository(REPO_NAME, mockedValues));
+
+    updateStep.doUpdate();
+
+    assertThat(getConfigStore().get().getMaxDiffLines()).isEqualTo(0);
+    assertThat(getConfigStore().get().isEmailPerPush()).isTrue();
+    assertThat(getConfigStore().get().isSendToRepositoryContact()).isTrue();
+    assertThat(getConfigStore().get().isUseAuthorAsFromAddress()).isFalse();
+    assertThat(getConfigStore().get().getContactList()).contains("abc@def.de");
+    assertThat(getConfigStore().get().getContactList()).contains("echo@off.de");
+    assertThat(getConfigStore().get().getContactList().size()).isEqualTo(3);
+  }
+
+  @Test
   public void shouldSkipRepositoriesIfPermissionsAreEmpty() {
     ImmutableMap<String, String> mockedValues =
       ImmutableMap.of(


### PR DESCRIPTION
## Proposed changes

When migrating from v1, the "maxDiffLines" property is parsed as an integer but may be an empty string in the migrated configuration xml. A safe parsing mechanism has been implemented to prevent the associated NumberFormatException from being thrown.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
