### PR TITLE
Let form be valid even without recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Let configuration be submittable even if no recipient is given ([#23](https://github.com/scm-manager/scm-notify-plugin/pull/23) and [#20](https://github.com/scm-manager/scm-notify-plugin/pull/20))
+
 ## 2.0.2 - 2021-06-07
 ### Fixed
 - Wrong permission check ([#11](https://github.com/scm-manager/scm-notify-plugin/pull/11))

--- a/src/main/js/NotifyConfigurationForm.tsx
+++ b/src/main/js/NotifyConfigurationForm.tsx
@@ -49,11 +49,7 @@ class NotifyConfigurationForm extends React.Component<Props, State> {
   }
 
   isValid() {
-    const { sendToRepositoryContact, contactList } = this.state;
-    // the configurations are valid if there is at minimum one receiver
-    if (contactList.length === 0 && !sendToRepositoryContact) {
-      return false;
-    }
+    const { contactList } = this.state;
     let valid = true;
     contactList.map(contact => {
       valid = valid && validator.isMailValid(contact);


### PR DESCRIPTION
## Proposed changes

It has to be possible to submit the configuration
form even if no recipient is given, simply to "disable"
the notifications.

Fixes #20 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
